### PR TITLE
Implement a simple echo server with a proxy server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DIR ?= build
 LLVM_PREFIX ?=
 
 # 自動起動するサーバのリスト
-BOOT_SERVERS ?= fs tcpip shell virtio_blk virtio_net pong
+BOOT_SERVERS ?= fs tcpip shell virtio_blk virtio_net pong echo
 
 # 起動時に自動実行するシェルコマンド (テストを自動化したいときに便利)
 #

--- a/libs/common/ipcstub.h
+++ b/libs/common/ipcstub.h
@@ -251,11 +251,11 @@ struct tcpip_closed_fields {
 };
 
 struct echo_fields {
-    uint8_t data[256];
+    uint8_t data[1024];
     size_t data_len;
 };
 struct echo_reply_fields {
-    uint8_t data[256];
+    uint8_t data[1024];
     size_t data_len;
 };
 

--- a/libs/common/ipcstub.h
+++ b/libs/common/ipcstub.h
@@ -250,6 +250,15 @@ struct tcpip_closed_fields {
     int sock;
 };
 
+struct echo_fields {
+    uint8_t data[256];
+    size_t data_len;
+};
+struct echo_reply_fields {
+    uint8_t data[256];
+    size_t data_len;
+};
+
 
 
 #define EXCEPTION_MSG 1
@@ -316,6 +325,8 @@ struct tcpip_closed_fields {
 #define TCPIP_DNS_RESOLVE_REPLY_MSG 62
 #define TCPIP_DATA_MSG 63
 #define TCPIP_CLOSED_MSG 64
+#define ECHO_MSG 65
+#define ECHO_REPLY_MSG 66
 
 //
 //  各種マクロの定義
@@ -385,8 +396,10 @@ struct tcpip_closed_fields {
     struct tcpip_dns_resolve_reply_fields tcpip_dns_resolve_reply; \
     struct tcpip_data_fields tcpip_data; \
     struct tcpip_closed_fields tcpip_closed; \
+    struct echo_fields echo; \
+    struct echo_reply_fields echo_reply; \
 
-#define IPCSTUB_MSGID_MAX 64
+#define IPCSTUB_MSGID_MAX 66
 #define IPCSTUB_MSGID2STR \
     (const char *[]){ \
      \
@@ -489,6 +502,9 @@ struct tcpip_closed_fields {
         [63] = "tcpip_data", \
      \
         [64] = "tcpip_closed", \
+     \
+        [65] = "echo", \
+        [66] = "echo_reply", \
      \
     }
 
@@ -748,5 +764,13 @@ struct tcpip_closed_fields {
     _Static_assert( \
         sizeof(struct tcpip_closed_fields) < 4096, \
         "'tcpip_closed' message is too large, should be less than 4096 bytes" \
+    ); \
+    _Static_assert( \
+        sizeof(struct echo_fields) < 4096, \
+        "'echo' message is too large, should be less than 4096 bytes" \
+    ); \
+    _Static_assert( \
+        sizeof(struct echo_reply_fields) < 4096, \
+        "'echo_reply' message is too large, should be less than 4096 bytes" \
     ); \
 

--- a/messages.idl
+++ b/messages.idl
@@ -138,4 +138,4 @@ oneway tcpip_closed(sock: int);
 // Echo Server
 //
 
-rpc echo(data: bytes[256]) -> (data: bytes[256]);
+rpc echo(data: bytes[1024]) -> (data: bytes[1024]);

--- a/messages.idl
+++ b/messages.idl
@@ -133,3 +133,9 @@ rpc tcpip_dns_resolve(hostname: cstr[256]) -> (addr: uint32);
 oneway tcpip_data(sock: int);
 // TCP/IPサーバからメッセージ: ソケットがクローズされた
 oneway tcpip_closed(sock: int);
+
+//
+// Echo Server
+//
+
+rpc echo(data: bytes[256]) -> (data: bytes[256]);

--- a/servers/echo/build.mk
+++ b/servers/echo/build.mk
@@ -1,0 +1,1 @@
+objs-y += main.o

--- a/servers/echo/main.c
+++ b/servers/echo/main.c
@@ -1,0 +1,27 @@
+#include <libs/common/print.h>
+#include <libs/common/message.h>
+#include <libs/user/ipc.h>
+
+int main(void) {
+    // Register as echo server.
+    ASSERT_OK(ipc_register("echo"));
+    TRACE("ready");
+
+    while (true) {
+        struct message m;
+        ASSERT_OK(ipc_recv(IPC_ANY, &m));
+
+        switch (m.type) {
+            case ECHO_MSG: {
+                DBG("received echo message from #%d (len = %d)", m.src, m.echo.data_len);
+                m.type = ECHO_REPLY_MSG;
+                // Assume that echo and echo_reply message have the same layout.
+                ipc_reply(m.src, &m);
+                break;
+            }
+            default:
+                WARN("unhandled message: %s (%x)", msgtype2str(m.type), m.type);
+                break;
+        }
+    }
+}

--- a/servers/proxy/build.mk
+++ b/servers/proxy/build.mk
@@ -1,0 +1,1 @@
+objs-y += main.o

--- a/servers/proxy/main.c
+++ b/servers/proxy/main.c
@@ -1,0 +1,66 @@
+#include <libs/common/message.h>
+#include <libs/common/print.h>
+#include <libs/common/string.h>
+#include <libs/user/ipc.h>
+
+int main(void) {
+    // Find {tcpip, echo} server.
+    task_t tcpip_server = ipc_lookup("tcpip");
+    task_t echo_server = ipc_lookup("echo");
+
+    // Listen on port 80.
+    struct message m;
+    m.type = TCPIP_LISTEN_MSG;
+    m.tcpip_listen.listen_port = 80;
+    ASSERT_OK(ipc_call(tcpip_server, &m));
+
+    while(true) {
+        ASSERT_OK(ipc_recv(IPC_ANY, &m));
+
+        DBG(
+            "received message from #%d: %s (%x)", m.src,
+            msgtype2str(m.type),
+            m.type
+        );
+        
+        switch(m.type) {
+            case TCPIP_CLOSED_MSG: {
+                // Destroy socket.
+                m.type = TCPIP_DESTROY_MSG;
+                m.tcpip_destroy.sock = m.tcpip_closed.sock;
+                ASSERT_OK(ipc_call(tcpip_server, &m));
+                break;
+            }
+            case TCPIP_DATA_MSG: {
+                int sock = m.tcpip_data.sock;
+
+                // Read the received data.
+                m.type = TCPIP_READ_MSG;
+                m.tcpip_read.sock = sock;
+                ASSERT_OK(ipc_call(tcpip_server, &m));
+
+                char data[1024];
+                size_t data_len = m.tcpip_read_reply.data_len;
+                memcpy(data, m.tcpip_read_reply.data, data_len);
+
+                DBG("received data (%u bytes) from socket %d", data_len, sock);
+
+                // Relay to the echo server.
+                m.type = ECHO_MSG;
+                m.echo.data_len = data_len;
+                memcpy(m.echo.data, data, data_len);
+                ASSERT_OK(ipc_call(echo_server, &m));
+                ASSERT(m.echo_reply.data_len == data_len);
+                
+                // Replay to the client.
+                memcpy(data, m.echo_reply.data, data_len);
+                m.type = TCPIP_WRITE_MSG;
+                m.tcpip_write.sock = sock;
+                memcpy(m.tcpip_write.data, data, data_len);
+                m.tcpip_write.data_len = data_len;
+                ASSERT_OK(ipc_call(tcpip_server, &m));
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary
Microkernels are well suited to microservices architectures. This is because the basis of microkernels is message passing, and applications are necessarily event-driven. To prove this, I implemented a simple echo server and a proxy server. The proxy server allows the echo server to communicate over the network **without modification.**

# How to use
- Add hostfwd option to QEMUFLAGS.
```
QEMUFLAGS += -netdev user,id=net0,hostfwd=tcp:127.0.0.1:1234-:80
```

- Run WasmOS on Qemu and execute the following command.
```
shell> start proxy
```

- Connect to localhost:1234 and send data.

![proxy](https://github.com/r1ru/WasmOS/assets/92210252/f69c4a8c-794f-4278-8b8d-4acee0188a20)




