### PR TITLE
Patch for C++ compatibility

### DIFF
--- a/libs/common/types.h
+++ b/libs/common/types.h
@@ -22,9 +22,11 @@ typedef uint32_t uintmax_t;
 #endif
 
 // 真偽値
+#ifndef __cplusplus
 typedef char bool;
 #define true  1
 #define false 0
+#endif
 
 // ヌルポインタ
 #define NULL ((void *) 0)


### PR DESCRIPTION
I want to make WasmOS servers application compiled to WebAssemly written in C++ and I tried it at my fork.
Compiling of C++ code without ipc call was succeeded so I want to try code with ipc.
But `#include <libs/common/types.h>` (via `#include <libs/wasm/ipc.h>`) makes compile error because of `typedef char bool`. `bool` is a keyword of C++ so this typedef is illegal in C++.
this patch surrounds `typedef char bool`(and `#define true` and `#define false`) with `#ifndef __cplusplus`and`#endif` so that we can compile C++ code calling ipc.

(actually, C code in C++ is not working without surrounding `extern "C" {}` because of name mangling but I currently solve it with `extern "C" { #include<...> }`. 
If you are willing to support C++ officially someday, please write a pair of `#ifdef __cplusplus extern "C" { #endif` and `#ifdef __cplusplus } #endif`  for the each header file)
